### PR TITLE
fix(sound): prevent audio playback during tests using Mute flag

### DIFF
--- a/internal/sound/sound.go
+++ b/internal/sound/sound.go
@@ -10,6 +10,8 @@ import (
 
 const sampleRate = 44100
 
+var Mute bool = false
+
 type note struct {
 	freq     float64
 	duration time.Duration
@@ -29,6 +31,9 @@ func generateTone(frequency float64, duration time.Duration) beep.Streamer {
 }
 
 func playSequence(notes []note) {
+	if Mute {
+		return 
+	}
 	speaker.Init(beep.SampleRate(sampleRate), sampleRate/10)
 
 	var streamers []beep.Streamer

--- a/internal/sound/sound_test.go
+++ b/internal/sound/sound_test.go
@@ -3,14 +3,17 @@ package sound
 import "testing"
 
 func TestThemeHobbits(t *testing.T) {
+	Mute = true 
 	ThemeHobbits()
 }
 
 func TestThemeElves(t *testing.T) {
+	Mute = true
 	ThemeElves()
 }
 
 func TestThemeAragorn(t *testing.T) {
+	Mute = true
 	ThemeAragorn()
 }
 


### PR DESCRIPTION
Introduced a global `Mute` variable in the sound package to disable audio playback when set to true. This allows running tests in environments without audio hardware (e.g., CI/CD) without hanging or crashing.

Also updated `TestThemeHobbits` to set `Mute = true` during test execution.