### PR TITLE
feat: automate release with precompiled Linux binary upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,6 @@ on:
       - 'img/**'
       - LICENSE
 
-
 jobs:
   release:
     name: Generate Release Aragomodoro
@@ -44,3 +43,21 @@ jobs:
           release_name: ${{ steps.tag_version.outputs.new_tag }}
           draft: false
           prerelease: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.22
+
+      - name: Build Aragomodoro binary
+        run: |
+          mkdir -p build
+          GOOS=linux GOARCH=amd64 go build -o build/aragomodoro ./cmd
+
+      - name: Upload Linux binary to release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          files: build/aragomodoro
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- add GitHub Actions workflow for release on push to main branch
- bump version and create GitHub release automatically
- build Linux amd64 binary in workflow
- upload built binary as release asset for easy download